### PR TITLE
Remove -w from test and add react-router@3.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,13 +26,14 @@
     "react": "^15.4.2",
     "react-addons-test-utils": "^15.4.2",
     "react-dom": "^15.4.2",
+    "react-router": "^3.0.2",
     "sinon": "^1.17.7",
     "superagent": "^3.3.2"
   },
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
-    "test": "mocha -w test/helpers/browser.js test/*.js",
+    "test": "mocha test/helpers/browser.js test/*.js",
     "dev:hot": "webpack-dev-server --hot --inline --progress --colors --watch --display-error-details --display-cached --content-base ./",
     "test:watch": "npm run test -- --watch",
     "eject": "react-scripts eject"


### PR DESCRIPTION
Removing the `-w` flag from off of test. `learn` calls `npm test` and you have to hard crash out of `learn` with `ctrl + C` if `-w` is on `npm test`

Also added `react-router` v 3.0.2 to the `package.json`

@Lukeghenco ^